### PR TITLE
fix: activation policy restrict to regular apps

### DIFF
--- a/window-switcher.xcodeproj/project.pbxproj
+++ b/window-switcher.xcodeproj/project.pbxproj
@@ -430,7 +430,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "window-switcher/window_switcher.entitlements";
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/window-switcher.xcodeproj/project.pbxproj
+++ b/window-switcher.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -446,7 +446,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.0;
+				MARKETING_VERSION = 0.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -68,8 +68,8 @@ func handleObserverEvent(observer: AXObserver, element: AXUIElement, notificatio
     }
 }
 
-func getAppsExcludingWindowSwitcher() -> [NSRunningApplication] {
-    return NSWorkspace.shared.runningApplications.filter({ $0.processIdentifier != getpid() && $0.activationPolicy == .regular })
+func getApps() -> [NSRunningApplication] {
+    return NSWorkspace.shared.runningApplications.filter({ $0.activationPolicy == .regular })
 }
 
 class Windows {
@@ -182,7 +182,7 @@ class Windows {
     }
     
     public func refreshWindows() {
-        let apps = getAppsExcludingWindowSwitcher()
+        let apps = getApps()
         
         // Get apps that have been closed, and apps that are new.
         var deleteObservers = applicationObservers
@@ -213,14 +213,14 @@ class Windows {
     }
     
     public func fullRefreshWindows() {
-        let apps = getAppsExcludingWindowSwitcher()
+        let apps = getApps()
         windows.removeAll()
         windows.append(contentsOf: Windows.getInitialWindows(apps))
         startObserving(apps: apps)
     }
     
     init() {
-        let apps = getAppsExcludingWindowSwitcher()
+        let apps = getApps()
         windows = Windows.getInitialWindows(apps)
         startObserving(apps: apps)
     }

--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -69,7 +69,7 @@ func handleObserverEvent(observer: AXObserver, element: AXUIElement, notificatio
 }
 
 func getAppsExcludingWindowSwitcher() -> [NSRunningApplication] {
-    return NSWorkspace.shared.runningApplications.filter({ $0.processIdentifier != getpid() })
+    return NSWorkspace.shared.runningApplications.filter({ $0.processIdentifier != getpid() && $0.activationPolicy == .regular })
 }
 
 class Windows {


### PR DESCRIPTION
This PR updates the filter for applications to not accept apps that do not have `regular` activation policies.