### PR TITLE
fix: no duplicate list item for opening minimized window

### DIFF
--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -62,7 +62,10 @@ func handleObserverEvent(observer: AXObserver, element: AXUIElement, notificatio
         let (appPID, _) = observerSelf.applicationObservers.first(where: { $0.value == observer })!
         if let app = NSRunningApplication(processIdentifier: appPID), let title = getWindowName(element: element) {
             let window = Window(id: element.hashValue, appName: app.localizedName ?? "Unknown", appPID: app.processIdentifier, name: title, element: element)
-            observerSelf.windows.append(window)
+            // Check if window is already in windows list.
+            if !observerSelf.windows.contains(window) {
+                observerSelf.windows.append(window)
+            }
         }
         break
     case kAXUIElementDestroyedNotification:


### PR DESCRIPTION
This PR updates the observer event handler to check if the window created is already in the list of windows. If so, it does not add a duplicate reference.

This fixes #11 