### PR TITLE
Fix Window equality

### DIFF
--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -14,9 +14,13 @@ struct Window : Hashable {
     var name: String
     
     var element: AXUIElement
-    
+
     func hash(into hasher: inout Hasher) {
         return element.hash(into: &hasher)
+    }
+
+    static func == (lhs: Window, rhs: Window) -> Bool {
+        return lhs.element == rhs.element
     }
     
     func fqn() -> String {


### PR DESCRIPTION
## Summary
- ensure `Window` equality uses only the underlying `AXUIElement`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68646b044f94832fa47d72a917307ee7