### PR TITLE
Index applications in search

### DIFF
--- a/window-switcher/Models/Applications.swift
+++ b/window-switcher/Models/Applications.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+struct Application: Hashable {
+    let name: String
+    let url: URL
+}
+
+func getInstalledApplications() -> [Application] {
+    let fileManager = FileManager.default
+    var apps: [Application] = []
+    let searchPaths = ["/Applications", "/System/Applications", "\(NSHomeDirectory())/Applications"]
+    for path in searchPaths {
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+        if let enumerator = fileManager.enumerator(at: url, includingPropertiesForKeys: nil) {
+            for case let appURL as URL in enumerator {
+                if appURL.pathExtension == "app" {
+                    enumerator.skipDescendants()
+                    let bundle = Bundle(url: appURL)
+                    let name = bundle?.object(forInfoDictionaryKey: "CFBundleName") as? String ?? appURL.deletingPathExtension().lastPathComponent
+                    apps.append(Application(name: name, url: appURL))
+                }
+            }
+        }
+    }
+    return apps
+}
+

--- a/window-switcher/Models/SearchItem.swift
+++ b/window-switcher/Models/SearchItem.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum SearchItem: Hashable {
+    case window(Window)
+    case application(Application)
+}

--- a/window-switcher/Views/ContentView.swift
+++ b/window-switcher/Views/ContentView.swift
@@ -21,20 +21,20 @@ struct ContentView: View {
                 ScrollViewReader { proxy in
                     ScrollView {
                         LazyVStack(spacing: 0) {
-                            ForEach(viewModel.windows.indices, id: \.self) { i in
-                                WindowListItemView(window: viewModel.windows[i], isSelected: i == viewModel.selectedWindowIndex)
+                            ForEach(viewModel.items.indices, id: \.self) { i in
+                                ResultListItemView(item: viewModel.items[i], isSelected: i == viewModel.selectedIndex)
                                     .onTapGesture {
-                                        if i == viewModel.selectedWindowIndex {
-                                            viewModel.toggleSelectedWindow()
+                                        if i == viewModel.selectedIndex {
+                                            viewModel.toggleSelectedItem()
                                         } else {
-                                            viewModel.selectedWindowIndex = i
+                                            viewModel.selectedIndex = i
                                         }
                                     }
                                     .focusable()
                                     .focusEffectDisabled()
                             }
                         }
-                        .onChange(of: viewModel.selectedWindowIndex, initial: true) { _, new in
+                        .onChange(of: viewModel.selectedIndex, initial: true) { _, new in
                             guard new != -1 else { return }
                             withAnimation {
                                 proxy.scrollTo(new, anchor: .center)
@@ -47,7 +47,7 @@ struct ContentView: View {
                     WindowImageView(cgImage: $viewModel.selectedWindowPreview)
                 }.padding()
             }
-            SearchBarView(searchText: $viewModel.searchText, searchPrompt: "Search Windows")
+            SearchBarView(searchText: $viewModel.searchText, searchPrompt: "Search Windows or Apps")
         }
         .background(VisualEffect().clipShape(RoundedRectangle(cornerRadius: 16)))
         .onKeyPress() { key in

--- a/window-switcher/Views/ResultListItemView.swift
+++ b/window-switcher/Views/ResultListItemView.swift
@@ -34,7 +34,7 @@ struct ResultListItemView: View {
         case .window(let w):
             return w.fqn()
         case .application(let app):
-            return app.name
+            return "Open App: \(app.name)"
         }
     }
 

--- a/window-switcher/Views/ResultListItemView.swift
+++ b/window-switcher/Views/ResultListItemView.swift
@@ -1,5 +1,5 @@
 //
-//  WindowListItemView.swift
+//  ResultListItemView.swift
 //  window-switcher
 //
 //  Created by Sean Zhang on 2024-12-27.
@@ -8,12 +8,12 @@
 import SwiftUI
 import AppKit
 
-struct WindowListItemView: View {
+struct ResultListItemView: View {
     @Environment(\.colorScheme) var colorScheme  // Get the system color scheme
-    let window: Window
+    let item: SearchItem
     let isSelected: Bool
     let fontSize: CGFloat = 14
-    
+
     func textColorForAccentColor() -> Color {
         // Calculate luminance of the accent color
         let accentColor = NSColor(Color.accentColor).usingColorSpace(.sRGB)!
@@ -28,10 +28,19 @@ struct WindowListItemView: View {
             return .black
         }
     }
-    
+
+    private func text() -> String {
+        switch item {
+        case .window(let w):
+            return w.fqn()
+        case .application(let app):
+            return app.name
+        }
+    }
+
     var body: some View {
         HStack {
-            Text(window.fqn())
+            Text(text())
                 // Yes you need maxHeight AND maxWidth infinity to
                 // make the text box extend all the way.
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- include installed applications in search results alongside open windows
- allow launching a selected application from results
- show combined results in UI and refresh application index on full refresh
- Fixes #4 

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme window-switcher build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689401a6e228832fb2480c86f2d20d9f