### PR TITLE
Fix option+tab hotkey propagating tab to previous app

### DIFF
--- a/window-switcher/App.swift
+++ b/window-switcher/App.swift
@@ -120,7 +120,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 return Unmanaged.passRetained(event)
             }
             let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-            let flags = NSEvent.ModifierFlags(rawValue: event.flags.rawValue)
+            let flags = NSEvent.ModifierFlags(rawValue: UInt(event.flags.rawValue))
             if keyCode == kVK_Tab &&
                 flags.intersection(.deviceIndependentFlagsMask) == .option {
                 let delegate = Unmanaged<AppDelegate>.fromOpaque(userInfo!).takeUnretainedValue()

--- a/window-switcher/App.swift
+++ b/window-switcher/App.swift
@@ -121,10 +121,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             }
             let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
             let flags = NSEvent.ModifierFlags(rawValue: event.flags.rawValue)
-            if keyCode == kVK_Tab && flags.contains(.option) {
+            if keyCode == kVK_Tab &&
+                flags.intersection(.deviceIndependentFlagsMask) == .option {
                 let delegate = Unmanaged<AppDelegate>.fromOpaque(userInfo!).takeUnretainedValue()
-                // TODO: Find a better way to deal with focus problems
-                delegate.showWindowSwitcher()
+                if delegate.mainWindow?.isKeyWindow == true {
+                    NSApp.hide(nil)
+                } else {
+                    delegate.showWindowSwitcher()
+                }
                 return nil
             }
             return Unmanaged.passRetained(event)


### PR DESCRIPTION
## Summary
- prevent option+tab hotkey from inserting a tab in the previously focused app
- add CGEvent tap for option+tab and clean up event tap on app termination

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f1cc3e60832f89c13c869fa0da8b