### PR TITLE
Fix application search to integrate results with window results

### DIFF
--- a/window-switcher.xcodeproj/project.pbxproj
+++ b/window-switcher.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.5;
+				MARKETING_VERSION = 0.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -446,7 +446,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 0.3.5;
+				MARKETING_VERSION = 0.3.6;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -174,9 +174,9 @@ class Windows {
         }
     }
     
-    public func search(_ query: String) -> [Window] {
+    public func search(_ query: String) -> [(Int16, Window)] {
         if query.isEmpty {
-            return windows
+            return windows.map({ (0, $0) })
         }
         
         var results: [(Int16, Window)] = []
@@ -191,7 +191,8 @@ class Windows {
         
         // Sort and return just the windows, without the score.
         results.sort(by: { $0.0 > $1.0 })
-        return results.map(\.1)
+        return results
+        // return results.map(\.1)
     }
     
     public func refreshWindows() {


### PR DESCRIPTION
This places application search results with window search results, so that the best overall match is the top result. Before, the application results would be *appended* instead of this desired behaviour.