### PR TITLE
Fix UI freeze by guarding hotkey toggling on main thread

### DIFF
--- a/window-switcher/App.swift
+++ b/window-switcher/App.swift
@@ -143,22 +143,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             if keyCode == kVK_Tab &&
                 flags.intersection(.deviceIndependentFlagsMask) == .option {
                 let delegate = Unmanaged<AppDelegate>.fromOpaque(userInfo!).takeUnretainedValue()
-                var shouldHandle = false
-                DispatchQueue.main.sync {
-                    if !delegate.isHotkeyActionInProgress {
-                        delegate.isHotkeyActionInProgress = true
-                        shouldHandle = true
+                let toggleOverlay = {
+                    guard !delegate.isHotkeyActionInProgress else { return }
+                    delegate.isHotkeyActionInProgress = true
+                    if delegate.isOverlayVisible {
+                        delegate.hideWindowSwitcher()
+                    } else {
+                        delegate.showWindowSwitcher()
                     }
+                    delegate.isHotkeyActionInProgress = false
                 }
-                if shouldHandle {
-                    DispatchQueue.main.async {
-                        if delegate.isOverlayVisible {
-                            delegate.hideWindowSwitcher()
-                        } else {
-                            delegate.showWindowSwitcher()
-                        }
-                        delegate.isHotkeyActionInProgress = false
-                    }
+                if Thread.isMainThread {
+                    toggleOverlay()
+                } else {
+                    DispatchQueue.main.sync(execute: toggleOverlay)
                 }
                 return nil
             }


### PR DESCRIPTION
## Summary
- Track hotkey execution and overlay visibility to avoid reentrant toggles
- Handle hotkey-triggered window changes on the main thread only

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -scheme window-switcher -project window-switcher.xcodeproj` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68a9c0e41368832fb9e387c3ecb4edd7