### PR TITLE
Rank blank switcher windows by last use

### DIFF
--- a/window-switcher.xcodeproj/project.pbxproj
+++ b/window-switcher.xcodeproj/project.pbxproj
@@ -484,7 +484,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 5.0;
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/window-switcher.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/window-switcher";
+					TEST_HOST = "$(BUILT_PRODUCTS_DIR)/window-switcher-dev.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/window-switcher-dev";
 			};
 			name = Debug;
 		};

--- a/window-switcher/Clients/WindowClient.swift
+++ b/window-switcher/Clients/WindowClient.swift
@@ -22,6 +22,17 @@ private func getWindowName(element: AXUIElement) -> String? {
     return trimmedTitle.isEmpty ? nil : trimmedTitle
 }
 
+private func getWindowAttribute(
+    _ attribute: CFString,
+    from element: AXUIElement
+) -> AXUIElement? {
+    guard let valueRef = getAttributeValue(attribute, from: element) else {
+        return nil
+    }
+
+    return valueRef as! AXUIElement
+}
+
 private func getRole(element: AXUIElement) -> String? {
     guard let roleRef = getAttributeValue(kAXRoleAttribute as CFString, from: element),
           let role = roleRef as? String else {
@@ -104,6 +115,7 @@ private func handleObserverEvent(
 
 final class WindowClient {
     private var windows: [Window]
+    private var recentWindowKeys: [WindowRecentUseKey]
     private var applicationObservers: [Int32: AXObserver] = [:]
     private let workspaceNotificationCenter = NSWorkspace.shared.notificationCenter
     private var workspaceObservers: [NSObjectProtocol] = []
@@ -111,6 +123,7 @@ final class WindowClient {
     init() {
         let apps = Self.getApps()
         windows = Self.getInitialWindows(apps)
+        recentWindowKeys = Self.seedRecentWindowKeys(for: windows)
         startObserving(apps: apps)
         startObservingWorkspace()
     }
@@ -124,7 +137,13 @@ final class WindowClient {
         windows
     }
 
+    func getWindowsByRecentUse() -> [Window] {
+        WindowRecentUse.orderedWindows(windows, recentKeys: recentWindowKeys)
+    }
+
     func focusWindow(_ window: Window) {
+        moveWindowToFront(window)
+
         let err = AXUIElementPerformAction(window.element, kAXRaiseAction as CFString)
         if err != .success {
             print("[\(window.appName)] Error raising window \(err)")
@@ -144,6 +163,7 @@ final class WindowClient {
     func refresh() {
         let apps = Self.getApps()
         windows = Self.getInitialWindows(apps)
+        recentWindowKeys = Self.seedRecentWindowKeys(for: windows)
         resetObservers()
         startObserving(apps: apps)
     }
@@ -217,8 +237,11 @@ final class WindowClient {
                 kAXWindowResizedNotification as CFString,
                 kAXWindowMiniaturizedNotification as CFString,
                 kAXWindowDeminiaturizedNotification as CFString,
+                kAXApplicationActivatedNotification as CFString,
                 kAXApplicationHiddenNotification as CFString,
                 kAXApplicationShownNotification as CFString,
+                kAXFocusedWindowChangedNotification as CFString,
+                kAXMainWindowChangedNotification as CFString,
                 kAXUIElementDestroyedNotification as CFString
             ]
 
@@ -257,10 +280,12 @@ final class WindowClient {
         let insertIndex = windows.firstIndex(where: { $0.appPID == appPID }) ?? windows.count
         windows.removeAll(where: { $0.appPID == appPID })
         windows.insert(contentsOf: updatedWindows, at: min(insertIndex, windows.count))
+        reconcileRecentWindowKeys()
     }
 
     private func removeWindows(for appPID: Int32) {
         windows.removeAll(where: { $0.appPID == appPID })
+        reconcileRecentWindowKeys()
     }
 
     private func syncWindows(for appPID: Int32) {
@@ -282,6 +307,36 @@ final class WindowClient {
         syncWindows(for: appPID)
     }
 
+    private func reconcileRecentWindowKeys() {
+        recentWindowKeys = WindowRecentUse.reconcile(recentWindowKeys, with: windows.map(\.recentUseKey))
+    }
+
+    private func moveWindowToFront(_ window: Window) {
+        recentWindowKeys = WindowRecentUse.movingToFront(window.recentUseKey, in: recentWindowKeys)
+    }
+
+    private func moveTrackedWindowToFront(element: AXUIElement) -> Bool {
+        guard let window = windows.first(where: { $0.element == element }) else {
+            return false
+        }
+
+        moveWindowToFront(window)
+        return true
+    }
+
+    private func moveFocusedWindowToFront(for appPID: Int32) {
+        let appElement = AXUIElementCreateApplication(appPID)
+
+        if let focusedWindow = getWindowAttribute(kAXFocusedWindowAttribute as CFString, from: appElement),
+           moveTrackedWindowToFront(element: focusedWindow) {
+            return
+        }
+
+        if let mainWindow = getWindowAttribute(kAXMainWindowAttribute as CFString, from: appElement) {
+            _ = moveTrackedWindowToFront(element: mainWindow)
+        }
+    }
+
     fileprivate func processNotification(observer: AXObserver, element: AXUIElement, notification: CFString) {
         switch String(notification) {
         case kAXTitleChangedNotification:
@@ -293,10 +348,12 @@ final class WindowClient {
                 guard let app = NSRunningApplication(processIdentifier: appPID),
                       let updatedWindow = makeWindow(element: element, app: app) else {
                     windows.remove(at: windowIdx)
+                    reconcileRecentWindowKeys()
                     return
                 }
 
                 windows[windowIdx] = updatedWindow
+                reconcileRecentWindowKeys()
             } else {
                 syncWindowIfNeeded(observer: observer, element: element)
             }
@@ -304,6 +361,7 @@ final class WindowClient {
         case kAXWindowMovedNotification, kAXWindowResizedNotification:
             if let windowIdx = windows.firstIndex(where: { $0.element == element }) {
                 windows[windowIdx].frame = getWindowFrame(element: element)
+                reconcileRecentWindowKeys()
             } else {
                 syncWindowIfNeeded(observer: observer, element: element)
             }
@@ -312,6 +370,27 @@ final class WindowClient {
              kAXWindowMiniaturizedNotification,
              kAXWindowDeminiaturizedNotification:
             syncWindowIfNeeded(observer: observer, element: element)
+
+        case kAXApplicationActivatedNotification:
+            guard let appPID = appPID(for: observer) else {
+                return
+            }
+
+            syncWindows(for: appPID)
+            moveFocusedWindowToFront(for: appPID)
+
+        case kAXFocusedWindowChangedNotification,
+             kAXMainWindowChangedNotification:
+            guard let appPID = appPID(for: observer) else {
+                return
+            }
+
+            if moveTrackedWindowToFront(element: element) {
+                return
+            }
+
+            syncWindows(for: appPID)
+            moveFocusedWindowToFront(for: appPID)
 
         case kAXApplicationHiddenNotification:
             guard let appPID = appPID(for: observer) else {
@@ -369,5 +448,57 @@ final class WindowClient {
 
     private static func getInitialWindows(_ apps: [NSRunningApplication]) -> [Window] {
         apps.flatMap(getWindows(for:))
+    }
+
+    private static func seedRecentWindowKeys(for windows: [Window]) -> [WindowRecentUseKey] {
+        let snapshot = windows.map(\.recentUseSnapshotEntry)
+        let candidates = getOnScreenWindowCandidates(for: windows)
+        return WindowRecentUse.seededKeys(snapshot: snapshot, from: candidates)
+    }
+
+    private static func getOnScreenWindowCandidates(for windows: [Window]) -> [WindowRecentUseSeedCandidate] {
+        let trackedPIDs = Set(windows.map(\.appPID))
+        guard !trackedPIDs.isEmpty,
+              let cgWindowInfo = CGWindowListCopyWindowInfo(
+                [.optionOnScreenOnly, .excludeDesktopElements],
+                kCGNullWindowID
+              ) as? [[String: Any]] else {
+            return []
+        }
+
+        return cgWindowInfo.compactMap { info in
+            guard let ownerPIDValue = info[kCGWindowOwnerPID as String] as? NSNumber,
+                  trackedPIDs.contains(ownerPIDValue.int32Value),
+                  let layerValue = info[kCGWindowLayer as String] as? NSNumber,
+                  layerValue.intValue == 0 else {
+                return nil
+            }
+
+            let appPID = ownerPIDValue.int32Value
+            let title = info[kCGWindowName as String] as? String
+            let titleKey = title.map { WindowTitleKey(appPID: appPID, title: $0) }
+            let recentUseKey = title.flatMap { title -> WindowRecentUseKey? in
+                guard let bounds = getBounds(from: info) else {
+                    return nil
+                }
+
+                return WindowRecentUseKey(appPID: appPID, title: title, size: bounds.size)
+            }
+
+            return WindowRecentUseSeedCandidate(titleKey: titleKey, recentUseKey: recentUseKey)
+        }
+    }
+
+    private static func getBounds(from info: [String: Any]) -> CGRect? {
+        guard let boundsDictionary = info[kCGWindowBounds as String] as? NSDictionary else {
+            return nil
+        }
+
+        var bounds = CGRect.zero
+        guard CGRectMakeWithDictionaryRepresentation(boundsDictionary, &bounds) else {
+            return nil
+        }
+
+        return bounds
     }
 }

--- a/window-switcher/Clients/WindowStreamClient.swift
+++ b/window-switcher/Clients/WindowStreamClient.swift
@@ -7,11 +7,6 @@
 
 import ScreenCaptureKit
 
-private struct WindowTitleKey: Hashable {
-    let appPID: Int32
-    let title: String
-}
-
 private struct WindowFrameKey: Hashable {
     let x: Int
     let y: Int

--- a/window-switcher/Models/WindowIdentity.swift
+++ b/window-switcher/Models/WindowIdentity.swift
@@ -1,0 +1,196 @@
+import AppKit
+
+struct WindowTitleKey: Hashable {
+    let appPID: Int32
+    let title: String
+}
+
+struct WindowSizeKey: Hashable {
+    let width: Int
+    let height: Int
+
+    init(_ frame: CGRect?) {
+        width = Int((frame?.size.width ?? 0).rounded())
+        height = Int((frame?.size.height ?? 0).rounded())
+    }
+
+    init(_ size: CGSize) {
+        width = Int(size.width.rounded())
+        height = Int(size.height.rounded())
+    }
+}
+
+struct WindowRecentUseKey: Hashable {
+    let titleKey: WindowTitleKey
+    let sizeKey: WindowSizeKey
+
+    init(appPID: Int32, title: String, frame: CGRect?) {
+        titleKey = WindowTitleKey(appPID: appPID, title: title)
+        sizeKey = WindowSizeKey(frame)
+    }
+
+    init(appPID: Int32, title: String, size: CGSize) {
+        titleKey = WindowTitleKey(appPID: appPID, title: title)
+        sizeKey = WindowSizeKey(size)
+    }
+}
+
+struct WindowRecentUseSnapshotEntry: Hashable {
+    let titleKey: WindowTitleKey
+    let recentUseKey: WindowRecentUseKey
+}
+
+struct WindowRecentUseSeedCandidate: Hashable {
+    let titleKey: WindowTitleKey?
+    let recentUseKey: WindowRecentUseKey?
+}
+
+extension Window {
+    var windowTitleKey: WindowTitleKey {
+        WindowTitleKey(appPID: appPID, title: name)
+    }
+
+    var recentUseKey: WindowRecentUseKey {
+        WindowRecentUseKey(appPID: appPID, title: name, frame: frame)
+    }
+
+    var recentUseSnapshotEntry: WindowRecentUseSnapshotEntry {
+        WindowRecentUseSnapshotEntry(
+            titleKey: windowTitleKey,
+            recentUseKey: recentUseKey
+        )
+    }
+}
+
+enum WindowRecentUse {
+    static func orderedWindows(_ windows: [Window], recentKeys: [WindowRecentUseKey]) -> [Window] {
+        var remainingIndicesByKey: [WindowRecentUseKey: [Int]] = [:]
+        for (index, window) in windows.enumerated() {
+            remainingIndicesByKey[window.recentUseKey, default: []].append(index)
+        }
+
+        var consumedIndices: Set<Int> = []
+        var orderedWindows: [Window] = []
+
+        for key in recentKeys {
+            guard var remainingIndices = remainingIndicesByKey[key],
+                  let index = remainingIndices.first else {
+                continue
+            }
+
+            remainingIndices.removeFirst()
+            if remainingIndices.isEmpty {
+                remainingIndicesByKey.removeValue(forKey: key)
+            } else {
+                remainingIndicesByKey[key] = remainingIndices
+            }
+
+            consumedIndices.insert(index)
+            orderedWindows.append(windows[index])
+        }
+
+        for (index, window) in windows.enumerated() where !consumedIndices.contains(index) {
+            orderedWindows.append(window)
+        }
+
+        return orderedWindows
+    }
+
+    static func reconcile(_ recentKeys: [WindowRecentUseKey], with availableKeys: [WindowRecentUseKey]) -> [WindowRecentUseKey] {
+        var remainingCounts: [WindowRecentUseKey: Int] = [:]
+        for key in availableKeys {
+            remainingCounts[key, default: 0] += 1
+        }
+
+        var reconciledKeys: [WindowRecentUseKey] = []
+
+        func appendIfAvailable(_ key: WindowRecentUseKey) {
+            guard let count = remainingCounts[key], count > 0 else {
+                return
+            }
+
+            reconciledKeys.append(key)
+            if count == 1 {
+                remainingCounts.removeValue(forKey: key)
+            } else {
+                remainingCounts[key] = count - 1
+            }
+        }
+
+        for key in recentKeys {
+            appendIfAvailable(key)
+        }
+
+        for key in availableKeys {
+            appendIfAvailable(key)
+        }
+
+        return reconciledKeys
+    }
+
+    static func movingToFront(_ key: WindowRecentUseKey, in recentKeys: [WindowRecentUseKey]) -> [WindowRecentUseKey] {
+        var reorderedKeys = recentKeys
+        if let existingIndex = reorderedKeys.firstIndex(of: key) {
+            reorderedKeys.remove(at: existingIndex)
+        }
+        reorderedKeys.insert(key, at: 0)
+        return reorderedKeys
+    }
+
+    static func seededKeys(
+        snapshot: [WindowRecentUseSnapshotEntry],
+        from candidates: [WindowRecentUseSeedCandidate]
+    ) -> [WindowRecentUseKey] {
+        seededIndices(snapshot: snapshot, from: candidates).map { snapshot[$0].recentUseKey }
+    }
+
+    static func seededIndices(
+        snapshot: [WindowRecentUseSnapshotEntry],
+        from candidates: [WindowRecentUseSeedCandidate]
+    ) -> [Int] {
+        var indicesByRecentUseKey: [WindowRecentUseKey: [Int]] = [:]
+        var indicesByTitleKey: [WindowTitleKey: [Int]] = [:]
+
+        for (index, entry) in snapshot.enumerated() {
+            indicesByRecentUseKey[entry.recentUseKey, default: []].append(index)
+            indicesByTitleKey[entry.titleKey, default: []].append(index)
+        }
+
+        var matchedIndices: Set<Int> = []
+        var seededIndices: [Int] = []
+
+        for candidate in candidates {
+            if let recentUseKey = candidate.recentUseKey,
+               let index = uniqueIndex(for: recentUseKey, from: indicesByRecentUseKey, excluding: matchedIndices) {
+                matchedIndices.insert(index)
+                seededIndices.append(index)
+                continue
+            }
+
+            if let titleKey = candidate.titleKey,
+               let index = uniqueIndex(for: titleKey, from: indicesByTitleKey, excluding: matchedIndices) {
+                matchedIndices.insert(index)
+                seededIndices.append(index)
+            }
+        }
+
+        for (index, _) in snapshot.enumerated() where !matchedIndices.contains(index) {
+            seededIndices.append(index)
+        }
+
+        return seededIndices
+    }
+
+    private static func uniqueIndex<Key: Hashable>(
+        for key: Key,
+        from indicesByKey: [Key: [Int]],
+        excluding matchedIndices: Set<Int>
+    ) -> Int? {
+        let candidateIndices = (indicesByKey[key] ?? []).filter { !matchedIndices.contains($0) }
+        guard candidateIndices.count == 1 else {
+            return nil
+        }
+
+        return candidateIndices[0]
+    }
+}

--- a/window-switcher/ViewModels/SwitcherViewModel.swift
+++ b/window-switcher/ViewModels/SwitcherViewModel.swift
@@ -2,6 +2,61 @@ import SwiftUI
 import AppKit
 import Observation
 
+enum SwitcherSearchMode {
+    case blankQuery
+    case searchQuery
+}
+
+enum SwitcherSearchResults {
+    static func orderedItems(
+        from resultScores: [(Int16, SearchItem)],
+        mode: SwitcherSearchMode
+    ) -> [SearchItem] {
+        switch mode {
+        case .blankQuery:
+            return resultScores.map(\.1)
+        case .searchQuery:
+            return resultScores
+                .sorted(by: compareSearchResults)
+                .map(\.1)
+        }
+    }
+
+    static func initialSelectionIndex(
+        resultCount: Int,
+        mode: SwitcherSearchMode
+    ) -> Int? {
+        guard resultCount > 0 else {
+            return nil
+        }
+
+        switch mode {
+        case .blankQuery:
+            return resultCount > 1 ? 1 : 0
+        case .searchQuery:
+            return 0
+        }
+    }
+
+    static func compareSearchResults(
+        lhs: (Int16, SearchItem),
+        rhs: (Int16, SearchItem)
+    ) -> Bool {
+        if lhs.0 != rhs.0 {
+            return lhs.0 > rhs.0
+        }
+
+        switch (lhs.1, rhs.1) {
+        case (.window, .application):
+            return true
+        case (.application, .window):
+            return false
+        default:
+            return false
+        }
+    }
+}
+
 extension SwitcherView {
     @MainActor
     @Observable
@@ -55,7 +110,7 @@ extension SwitcherView {
             }
         }
         var selectedItemPreview: CGImage?
-        
+
         // Utilities
         let windowClient: WindowClient
         let streamClient: WindowStreamClient
@@ -66,7 +121,7 @@ extension SwitcherView {
             // Seed initial results
             search()
         }
-        
+
         // Handlers
         /// Callback for when an a search item is switched to.
         func enterItem(_ item: SearchItem) {
@@ -81,52 +136,55 @@ extension SwitcherView {
             // Perform some cleanup.
             searchText = ""
         }
-        
+
         private func curSelectedItemIndex() -> Int? {
             guard let selectedItem, let index = searchItems.firstIndex(of: selectedItem) else {
                 return nil
             }
             return index
         }
-            
+
         /// Handler when the user wants to select the previous item in the list.
         func selectPrev() {
             // Get index of current selected item. If it doesn't exist, this function no-ops.
             guard let currentIndex = curSelectedItemIndex(), !searchItems.isEmpty else {
                 return
             }
-            
+
             // Set selected item to previous, with circular wraparound (if it's the 0th item)
             let newIndex = (currentIndex - 1 + searchItems.count) % searchItems.count
             selectedItem = searchItems[newIndex]
         }
-        
+
         /// Handler when the user wants to select the next item in the list.
         func selectNext() {
             // Get index of current selected item. If it doesn't exist, no-op.
             guard let currentIndex = curSelectedItemIndex(), !searchItems.isEmpty else {
                 return
             }
-            
+
             let newIndex = (currentIndex + 1) % searchItems.count
             selectedItem = searchItems[newIndex]
         }
-        
+
         /// Gets the most relevant results based on the search text.
         private func search() {
             applicationSearchTask?.cancel()
 
             let query = searchText
+            if query.isEmpty {
+                let windowResults = windowClient.getWindowsByRecentUse()
+                    .map { (Int16(0), SearchItem.window($0)) }
+                applySearchResults(windowResults, mode: .blankQuery)
+                return
+            }
+
             let windowResults = Windows.search(
                 query,
                 windowClient.getWindows()
             ).map { ( $0.0, SearchItem.window($0.1) ) }
 
-            applySearchResults(windowResults)
-
-            guard !query.isEmpty else {
-                return
-            }
+            applySearchResults(windowResults, mode: .searchQuery)
 
             applicationSearchTask = Task { [weak self] in
                 guard let self else {
@@ -139,35 +197,26 @@ extension SwitcherView {
                 }
 
                 self.applySearchResults(
-                    windowResults + appResults.map { ( $0.0, SearchItem.application($0.1) ) }
+                    windowResults + appResults.map { ( $0.0, SearchItem.application($0.1) ) },
+                    mode: .searchQuery
                 )
             }
         }
 
-        private func applySearchResults(_ resultScores: [(Int16, SearchItem)]) {
-            let results = resultScores
-                .sorted(by: Self.compareSearchResults)
-                .map(\.1)
-
+        private func applySearchResults(
+            _ resultScores: [(Int16, SearchItem)],
+            mode: SwitcherSearchMode
+        ) {
+            let results = SwitcherSearchResults.orderedItems(from: resultScores, mode: mode)
             searchItems = results
-            selectedItem = results.first
-        }
 
-        private static func compareSearchResults(
-            lhs: (Int16, SearchItem),
-            rhs: (Int16, SearchItem)
-        ) -> Bool {
-            if lhs.0 != rhs.0 {
-                return lhs.0 > rhs.0
-            }
-
-            switch (lhs.1, rhs.1) {
-            case (.window, .application):
-                return true
-            case (.application, .window):
-                return false
-            default:
-                return false
+            if let selectedIndex = SwitcherSearchResults.initialSelectionIndex(
+                resultCount: results.count,
+                mode: mode
+            ) {
+                selectedItem = results[selectedIndex]
+            } else {
+                selectedItem = nil
             }
         }
     }

--- a/window-switcherTests/window_switcherTests.swift
+++ b/window-switcherTests/window_switcherTests.swift
@@ -1,17 +1,120 @@
-//
-//  window_switcherTests.swift
-//  window-switcherTests
-//
-//  Created by Sean Zhang on 2024-12-27.
-//
-
+import AppKit
 import Testing
+#if canImport(window_switcher_dev)
+@testable import window_switcher_dev
+#else
 @testable import window_switcher
+#endif
 
 struct window_switcherTests {
+    @Test func blankQueryUsesRecentWindowOrder() {
+        let first = makeWindow(pid: 101, appName: "Mail", title: "Inbox")
+        let second = makeWindow(pid: 102, appName: "Notes", title: "Today")
+        let third = makeWindow(pid: 103, appName: "Terminal", title: "shell")
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+        let ordered = WindowRecentUse.orderedWindows(
+            [first, second, third],
+            recentKeys: [third.recentUseKey, first.recentUseKey, second.recentUseKey]
+        )
+
+        #expect(ordered.map(\.name) == ["shell", "Inbox", "Today"])
     }
 
+    @Test func blankQuerySelectionSkipsMostRecentWindow() {
+        let selectedIndex = SwitcherSearchResults.initialSelectionIndex(
+            resultCount: 3,
+            mode: .blankQuery
+        )
+
+        #expect(selectedIndex == 1)
+    }
+
+    @Test func blankQuerySelectionKeepsSingleWindowSelected() {
+        let selectedIndex = SwitcherSearchResults.initialSelectionIndex(
+            resultCount: 1,
+            mode: .blankQuery
+        )
+
+        #expect(selectedIndex == 0)
+    }
+
+    @Test func nonEmptyQueryStillRanksByFuzzyScore() {
+        let windows = [
+            makeWindow(pid: 201, appName: "Safari", title: "Documentation"),
+            makeWindow(pid: 202, appName: "Terminal", title: "Terminal")
+        ]
+
+        let results = Windows.search("terminal", windows)
+
+        #expect(results.map(\.1.name) == ["Terminal"])
+    }
+
+    @Test func equalScoresPreferWindowsOverApplications() {
+        let window = makeWindow(pid: 301, appName: "Notes", title: "Meeting Notes")
+        let application = Application(
+            name: "Notes",
+            url: URL(fileURLWithPath: "/Applications/Notes.app")
+        )
+
+        let ordered = SwitcherSearchResults.orderedItems(
+            from: [
+                (10, .application(application)),
+                (10, .window(window))
+            ],
+            mode: .searchQuery
+        )
+
+        #expect(ordered == [.window(window), .application(application)])
+    }
+
+    @Test func reconcileDropsMissingWindowsAndAppendsNewOnes() {
+        let first = WindowRecentUseKey(appPID: 401, title: "One", size: CGSize(width: 600, height: 400))
+        let second = WindowRecentUseKey(appPID: 402, title: "Two", size: CGSize(width: 700, height: 500))
+        let third = WindowRecentUseKey(appPID: 403, title: "Three", size: CGSize(width: 800, height: 600))
+
+        let reconciled = WindowRecentUse.reconcile(
+            [second, first],
+            with: [first, third]
+        )
+
+        #expect(reconciled == [first, third])
+    }
+
+    @Test func seedPreservesSnapshotOrderForAmbiguousDuplicates() {
+        let duplicateKey = WindowRecentUseKey(appPID: 501, title: "Notes", size: CGSize(width: 900, height: 700))
+        let duplicateTitle = duplicateKey.titleKey
+        let uniqueKey = WindowRecentUseKey(appPID: 502, title: "Terminal", size: CGSize(width: 1000, height: 700))
+
+        let snapshot = [
+            WindowRecentUseSnapshotEntry(titleKey: duplicateTitle, recentUseKey: duplicateKey),
+            WindowRecentUseSnapshotEntry(titleKey: duplicateTitle, recentUseKey: duplicateKey),
+            WindowRecentUseSnapshotEntry(titleKey: uniqueKey.titleKey, recentUseKey: uniqueKey)
+        ]
+
+        let seededIndices = WindowRecentUse.seededIndices(
+            snapshot: snapshot,
+            from: [
+                WindowRecentUseSeedCandidate(titleKey: duplicateTitle, recentUseKey: duplicateKey),
+                WindowRecentUseSeedCandidate(titleKey: uniqueKey.titleKey, recentUseKey: uniqueKey)
+            ]
+        )
+
+        #expect(seededIndices == [2, 0, 1])
+    }
+}
+
+private func makeWindow(
+    pid: Int32,
+    appName: String,
+    title: String,
+    frame: CGRect = CGRect(x: 10, y: 10, width: 800, height: 600)
+) -> Window {
+    Window(
+        id: Int(pid),
+        appName: appName,
+        appPID: pid,
+        name: title,
+        frame: frame,
+        element: AXUIElementCreateApplication(pid)
+    )
 }


### PR DESCRIPTION
This updates blank-query switcher results to use window MRU order instead of raw accessibility enumeration, seeded from the current on-screen z-order and kept fresh with accessibility focus notifications. It also changes the default blank-query selection to the next-most-recent window while leaving typed search ranking unchanged. The PR adds shared window identity and MRU helper logic, reuses the shared title key in preview matching, and adds unit coverage for ordering, selection, reconciliation, and ambiguous seeding behavior. It also fixes the Debug test host path so the test target builds against the dev app product.