### PR TITLE
Feature: Display app icons in result list items

### DIFF
--- a/window-switcher.xcodeproj/project.pbxproj
+++ b/window-switcher.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.5.0;
+				MARKETING_VERSION = 0.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher-dev";
 				PRODUCT_NAME = "$(TARGET_NAME)-dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -465,7 +465,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.5.0;
+				MARKETING_VERSION = 0.5.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/window-switcher/ViewModels/SwitcherViewModel.swift
+++ b/window-switcher/ViewModels/SwitcherViewModel.swift
@@ -105,6 +105,12 @@ extension SwitcherView {
         }
         var selectedItemPreview: CGImage?
 
+        // Icon caches keyed by PID (windows) and URL path (apps).
+        // Valid for the lifetime of the ViewModel (one switcher session),
+        // since PIDs and app bundles don't change mid-session.
+        @ObservationIgnored private var windowIconCache: [Int32: NSImage] = [:]
+        @ObservationIgnored private var appIconCache: [String: NSImage] = [:]
+
         // Utilities
         let windowClient: WindowClient
         let streamClient: WindowStreamClient
@@ -129,6 +135,29 @@ extension SwitcherView {
 
             // Perform some cleanup.
             searchText = ""
+        }
+
+        /// Returns the cached app icon for a search item, fetching and caching on first access.
+        func icon(for item: SearchItem) -> NSImage {
+            switch item {
+            case .window(let w):
+                if let cached = windowIconCache[w.appPID] {
+                    return cached
+                }
+                let img = NSRunningApplication(processIdentifier: w.appPID)?.icon
+                    ?? NSImage(named: NSImage.applicationIconName)
+                    ?? NSImage()
+                windowIconCache[w.appPID] = img
+                return img
+            case .application(let app):
+                let path = app.url.path
+                if let cached = appIconCache[path] {
+                    return cached
+                }
+                let img = NSWorkspace.shared.icon(forFile: path)
+                appIconCache[path] = img
+                return img
+            }
         }
 
         private func curSelectedItemIndex() -> Int? {

--- a/window-switcher/Views/ResultListItemView.swift
+++ b/window-switcher/Views/ResultListItemView.swift
@@ -13,6 +13,7 @@ struct ResultListItemView: View {
     let item: SearchItem
     let isSelected: Bool
     let fontSize: CGFloat = 14
+    let icon: NSImage
 
     func textColorForAccentColor() -> Color {
         // Calculate luminance of the accent color
@@ -39,7 +40,11 @@ struct ResultListItemView: View {
     }
 
     var body: some View {
-        HStack {
+        HStack(spacing: 8) {
+            Image(nsImage: icon)
+                .resizable()
+                .frame(width: 20, height: 20)
+                .accessibilityHidden(true)
             Text(text())
                 // Yes you need maxHeight AND maxWidth infinity to
                 // make the text box extend all the way.

--- a/window-switcher/Views/SwitcherView.swift
+++ b/window-switcher/Views/SwitcherView.swift
@@ -79,7 +79,7 @@ struct SwitcherView: View {
     }
 
     private func rowView(for item: SearchItem) -> some View {
-        ResultListItemView(item: item, isSelected: item == viewModel.selectedItem)
+        ResultListItemView(item: item, isSelected: item == viewModel.selectedItem, icon: viewModel.icon(for: item))
             .onTapGesture {
                 if item == viewModel.selectedItem {
                     viewModel.enterItem(item)


### PR DESCRIPTION
NOTE: DID NOT FIX GREY FLASHING IN PREVIEWS.
- Commits in this PR with those changes have been reverted

Original PR Link: https://github.com/dundeezhang/window-switcher-test/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Result rows now show an app/window icon at the start of each row for quicker visual identification.
* **Style**
  * Row spacing tightened for a more compact, consistent list layout.
* **Performance**
  * Per-session icon caching reduces repeated icon loads for smoother, more stable visuals.
* **Accessibility**
  * Icons are decorative and excluded from accessibility output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->