### PR TITLE
feat: add launch on startup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Window Switcher is a simple searchable window switcher for macOS.
 1. Use the configured hotkey to open the window switcher. The default is `Option+Tab`.
 2. Type to search for a window, or use arrow keys to move your selection.
 3. Press `enter` to switch to the selected window.
+4. Use the menu bar extra toggle to have Window Switcher launch on startup.
 
 ## Configuration
 
@@ -63,3 +64,4 @@ brew upgrade window-switcher
 - [x] Get window previews
 - [x] User-defined hotkey bindings
 - [x] Fuzzy-search for applications
+- [x] Launch on startup

--- a/window-switcher/App.swift
+++ b/window-switcher/App.swift
@@ -16,6 +16,7 @@ let versionIdentifier = Bundle.main.infoDictionary?["CFBundleShortVersionString"
 @main
 struct window_switcherApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+    @State private var launchAtLoginManager = LaunchAtLoginManager.shared
     
     var body: some Scene {
         MenuBarExtra("Windows", systemImage: "macwindow") {
@@ -42,9 +43,20 @@ struct window_switcherApp: App {
                 Button("Open Config...") {
                     appDelegate.openConfigFileFromMenu()
                 }
+                Toggle(
+                    "Launch on Startup",
+                    isOn: Binding(
+                        get: { launchAtLoginManager.isEnabled },
+                        set: { appDelegate.setLaunchAtLoginEnabled($0) }
+                    )
+                )
                 Button("Refresh Windows") {
                     appDelegate.refreshWindows()
                 }.keyboardShortcut("r")
+                if launchAtLoginManager.needsApproval {
+                    Text("Waiting for Login Items approval")
+                        .foregroundStyle(.secondary)
+                }
                 Divider()
                 Button("Quit", role: .destructive) {
                     NSApplication.shared.terminate(nil)

--- a/window-switcher/AppDelegate.swift
+++ b/window-switcher/AppDelegate.swift
@@ -12,6 +12,7 @@ import HotKey
 class AppDelegate: NSObject, NSApplicationDelegate {
     var window : NSWindow?
     var hotKey : HotKey?
+    let launchAtLoginManager = LaunchAtLoginManager.shared
     
     // Long-lived clients to preserve caches across panels
     let windowClient = WindowClient()
@@ -22,6 +23,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         ensureAccessibilityPermission()
         ConfigStore.shared.reload()
+        launchAtLoginManager.refreshStatus()
         Task {
             await ApplicationIndex.shared.preload()
         }
@@ -71,6 +73,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         } catch {
             presentErrorAlert(
                 title: "Unable to Open Config",
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    func setLaunchAtLoginEnabled(_ enabled: Bool) {
+        do {
+            try launchAtLoginManager.setEnabled(enabled)
+
+            if launchAtLoginManager.needsApproval {
+                presentInfoAlert(
+                    title: "Approval Needed",
+                    message: "Approve Window Switcher in System Settings > General > Login Items to finish enabling launch on startup."
+                )
+            }
+        } catch {
+            launchAtLoginManager.refreshStatus()
+            presentErrorAlert(
+                title: "Unable to Update Launch on Startup",
                 message: error.localizedDescription
             )
         }
@@ -133,6 +154,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentInfoAlert(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .informational
         alert.addButton(withTitle: "OK")
         alert.runModal()
     }

--- a/window-switcher/LaunchAtLoginManager.swift
+++ b/window-switcher/LaunchAtLoginManager.swift
@@ -1,0 +1,43 @@
+import Foundation
+import ServiceManagement
+import Observation
+
+@MainActor
+@Observable
+final class LaunchAtLoginManager {
+    static let shared = LaunchAtLoginManager()
+
+    private(set) var isEnabled = false
+    private(set) var needsApproval = false
+
+    private init() {
+        refreshStatus()
+    }
+
+    func refreshStatus() {
+        switch SMAppService.mainApp.status {
+        case .enabled:
+            isEnabled = true
+            needsApproval = false
+        case .requiresApproval:
+            isEnabled = true
+            needsApproval = true
+        case .notRegistered, .notFound:
+            isEnabled = false
+            needsApproval = false
+        @unknown default:
+            isEnabled = false
+            needsApproval = false
+        }
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+
+        refreshStatus()
+    }
+}


### PR DESCRIPTION
## Summary

Adds launch-on-startup support to the macOS app.

This change:
- adds a `LaunchAtLoginManager` around `SMAppService.mainApp`
- exposes a `Launch on Startup` toggle in the menu bar extra
- refreshes and applies launch-at-login state from the app delegate
- surfaces approval and failure states with user-facing alerts
- documents the feature in the README

## Why

Window Switcher did not have a built-in way to register itself as a login item. This adds the native macOS launch-at-login flow without introducing a separate helper target.

## User Impact

Users can enable launch on startup directly from the menu bar extra. On first enable, macOS may still require approval in System Settings > General > Login Items before the app launches automatically at login.