### PR TITLE
feat: alternative search

### DIFF
--- a/window-switcher/Models/Applications.swift
+++ b/window-switcher/Models/Applications.swift
@@ -38,8 +38,8 @@ actor ApplicationIndex {
         }
 
         return await applications().compactMap { app in
-            let score = FuzzyCompare(query.lowercased(), app.name.lowercased())
-            guard score > 3 else {
+            let score = FuzzySearch.match(query, against: app.name).score
+            guard score > 0 else {
                 return nil
             }
 

--- a/window-switcher/Models/SearchItem.swift
+++ b/window-switcher/Models/SearchItem.swift
@@ -3,4 +3,13 @@ import Foundation
 enum SearchItem: Hashable {
     case window(Window)
     case application(Application)
+
+    var sortLabel: String {
+        switch self {
+        case .window(let window):
+            return FuzzySearch.normalize(window.fqn())
+        case .application(let application):
+            return FuzzySearch.normalize(application.name)
+        }
+    }
 }

--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -28,10 +28,21 @@ final class Windows {
        }
 
        var results: [(Int16, Window)] = []
+       let includeCombinedScore = FuzzySearch.hasMultipleTerms(query)
 
        for window in windows {
-           let score = FuzzyCompare(query.lowercased(), window.fqn().lowercased())
-           if score > 3 {
+           let titleMatch = FuzzySearch.match(query, against: window.name)
+           let appMatch = FuzzySearch.match(query, against: window.appName)
+           let combinedScore = includeCombinedScore
+               ? FuzzySearch.match(query, against: window.fqn()).score + 25
+               : 0
+           let score = max(
+               titleMatch.score + 80,
+               appMatch.score + 15,
+               combinedScore
+           )
+
+           if score > 0 {
                results.append((score, window))
            }
        }

--- a/window-switcher/Utils/FuzzySearch.swift
+++ b/window-switcher/Utils/FuzzySearch.swift
@@ -1,40 +1,160 @@
-// FuzzyCompare takes two strings and computes a similarity score between the two.
-func FuzzyCompare(_ string1: String, _ string2: String) -> Int16 {
-    let m = string1.lengthOfBytes(using: .utf8)
-    let n = string2.lengthOfBytes(using: .utf8)
-    
-    var H = Array(repeating: Array(repeating: Int16(0), count: n + 1), count: m + 1)
-    var highestScore = Int16(0)
-    
-    for (i, c1) in string1.enumerated() {
-        // Shadow the index since the matrix requires the first column to be zeroed out.
-        let i = i + 1
-        for (j, c2) in string2.enumerated() {
-            // Shadow the index since the matrix requires the first row to be zeroed out.
-            let j = j + 1
-            let isFirst = i == 1 && j == 1
-                    
-            // This is a simplification due to our choice of a linear gap penalty.
-            H[i][j] = max(
-                H[i - 1][j - 1] + (isFirst ? 2 : 1) * score(c1, c2), // Add bias if first character is a match.
-                H[i - 1][j] - 1 * gapPenaltyMultiplier,
-                H[i][j - 1] - 1 * gapPenaltyMultiplier
-            )
-            
-            highestScore = max(highestScore, H[i][j])
-        }
+import Foundation
+
+struct FuzzySearch {
+    struct Match: Equatable {
+        let score: Int16
+        let matched: Bool
+        let isExactMatch: Bool
+        let isPrefixMatch: Bool
+        let isTokenPrefixMatch: Bool
+        let matchedSpan: Int
+        let matchedCount: Int
     }
-    
-    // After filling in the matrix, get the max value.
-    return highestScore
+
+    static func match(_ query: String, against candidate: String) -> Match {
+        let normalizedQuery = normalize(query)
+        let normalizedCandidate = normalize(candidate)
+
+        guard !normalizedQuery.isEmpty, !normalizedCandidate.isEmpty else {
+            return Match(
+                score: 0,
+                matched: false,
+                isExactMatch: false,
+                isPrefixMatch: false,
+                isTokenPrefixMatch: false,
+                matchedSpan: .max,
+                matchedCount: 0
+            )
+        }
+
+        let queryChars = Array(normalizedQuery)
+        let candidateChars = Array(normalizedCandidate)
+
+        var queryIndex = 0
+        var score = 0
+        var matchedIndices: [Int] = []
+        var previousMatchIndex: Int?
+
+        for candidateIndex in candidateChars.indices {
+            guard queryIndex < queryChars.count else {
+                break
+            }
+
+            if candidateChars[candidateIndex] != queryChars[queryIndex] {
+                continue
+            }
+
+            matchedIndices.append(candidateIndex)
+            score += 10
+
+            if candidateIndex == 0 {
+                score += 20
+            } else {
+                let previousCharacter = candidateChars[candidateIndex - 1]
+                if isBoundaryCharacter(previousCharacter) {
+                    score += 18
+                }
+            }
+
+            if let previousMatchIndex {
+                let gap = candidateIndex - previousMatchIndex - 1
+                if gap == 0 {
+                    score += 15
+                } else {
+                    score -= min(gap * 2, 12)
+                }
+            }
+
+            previousMatchIndex = candidateIndex
+            queryIndex += 1
+        }
+
+        guard queryIndex == queryChars.count, let firstIndex = matchedIndices.first, let lastIndex = matchedIndices.last else {
+            return Match(
+                score: 0,
+                matched: false,
+                isExactMatch: false,
+                isPrefixMatch: false,
+                isTokenPrefixMatch: false,
+                matchedSpan: .max,
+                matchedCount: 0
+            )
+        }
+
+        let isExactMatch = normalizedQuery == normalizedCandidate
+        let isPrefixMatch = normalizedCandidate.hasPrefix(normalizedQuery)
+        let isTokenPrefixMatch = tokenPrefixRanges(in: candidateChars).contains { range in
+            candidateSubstring(candidateChars, range).hasPrefix(normalizedQuery)
+        }
+        let matchedSpan = lastIndex - firstIndex + 1
+
+        if isExactMatch {
+            score += 80
+        } else if isPrefixMatch {
+            score += 45
+        } else if isTokenPrefixMatch {
+            score += 30
+        } else if normalizedCandidate.contains(normalizedQuery) {
+            score += 20
+        }
+
+        score -= min(max(matchedSpan - queryChars.count, 0), 20)
+        score -= min(max(candidateChars.count - queryChars.count, 0) / 8, 6)
+
+        return Match(
+            score: Int16(max(score, 0)),
+            matched: true,
+            isExactMatch: isExactMatch,
+            isPrefixMatch: isPrefixMatch,
+            isTokenPrefixMatch: isTokenPrefixMatch,
+            matchedSpan: matchedSpan,
+            matchedCount: matchedIndices.count
+        )
+    }
+
+    static func normalize(_ string: String) -> String {
+        string
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: .current)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    static func hasMultipleTerms(_ string: String) -> Bool {
+        normalize(string).contains(where: isBoundaryCharacter)
+    }
+
+    private static func isBoundaryCharacter(_ character: Character) -> Bool {
+        character == " " || character == ":" || character == "/" || character == "-" || character == "_"
+    }
+
+    private static func tokenPrefixRanges(in characters: [Character]) -> [Range<Int>] {
+        guard !characters.isEmpty else {
+            return []
+        }
+
+        var ranges: [Range<Int>] = []
+        var tokenStart = 0
+
+        for index in characters.indices {
+            if isBoundaryCharacter(characters[index]) {
+                if tokenStart < index {
+                    ranges.append(tokenStart..<index)
+                }
+                tokenStart = index + 1
+            }
+        }
+
+        if tokenStart < characters.count {
+            ranges.append(tokenStart..<characters.count)
+        }
+
+        return ranges
+    }
+
+    private static func candidateSubstring(_ characters: [Character], _ range: Range<Int>) -> String {
+        String(characters[range])
+    }
 }
 
-let gapPenaltyMultiplier = Int16(6)
-
-func score(_ c1: Character, _ c2: Character) -> Int16 {
-    if c1 == c2 {
-        return 3
-    }
-    
-    return -3
+func FuzzyCompare(_ string1: String, _ string2: String) -> Int16 {
+    FuzzySearch.match(string1, against: string2).score
 }

--- a/window-switcher/ViewModels/SwitcherViewModel.swift
+++ b/window-switcher/ViewModels/SwitcherViewModel.swift
@@ -46,7 +46,7 @@ enum SwitcherSearchResults {
         case (.application, .window):
             return false
         default:
-            return false
+            return lhs.1.sortLabel < rhs.1.sortLabel
         }
     }
 }

--- a/window-switcherTests/window_switcherTests.swift
+++ b/window-switcherTests/window_switcherTests.swift
@@ -49,6 +49,40 @@ struct window_switcherTests {
         #expect(results.map(\.1.name) == ["Terminal"])
     }
 
+    @Test func fuzzySearchPrefersPrefixOverLooseSubsequence() {
+        let prefix = FuzzySearch.match("saf", against: "Safari")
+        let loose = FuzzySearch.match("saf", against: "Debug Safari Window")
+
+        #expect(prefix.score > loose.score)
+        #expect(prefix.isPrefixMatch)
+    }
+
+    @Test func fuzzySearchRewardsTokenPrefixMatches() {
+        let tokenPrefix = FuzzySearch.match("chr", against: "Google Chrome")
+        let loose = FuzzySearch.match("chr", against: "Archive Browser")
+
+        #expect(tokenPrefix.score > loose.score)
+        #expect(tokenPrefix.isTokenPrefixMatch)
+    }
+
+    @Test func fuzzySearchIsDiacriticInsensitive() {
+        let match = FuzzySearch.match("cafe", against: "Café")
+
+        #expect(match.matched)
+        #expect(match.score > 0)
+    }
+
+    @Test func windowSearchPrefersTitleMatchOverAppNameOnlyMatch() {
+        let windows = [
+            makeWindow(pid: 211, appName: "Terminal", title: "Build Logs"),
+            makeWindow(pid: 212, appName: "Notes", title: "Terminal Migration")
+        ]
+
+        let results = Windows.search("terminal", windows)
+
+        #expect(results.map(\.1.name) == ["Terminal Migration", "Build Logs"])
+    }
+
     @Test func equalScoresPreferWindowsOverApplications() {
         let window = makeWindow(pid: 301, appName: "Notes", title: "Meeting Notes")
         let application = Application(
@@ -65,6 +99,21 @@ struct window_switcherTests {
         )
 
         #expect(ordered == [.window(window), .application(application)])
+    }
+
+    @Test func equalScoreWindowsSortDeterministically() {
+        let alpha = makeWindow(pid: 311, appName: "App", title: "Alpha")
+        let beta = makeWindow(pid: 312, appName: "App", title: "Beta")
+
+        let ordered = SwitcherSearchResults.orderedItems(
+            from: [
+                (10, .window(beta)),
+                (10, .window(alpha))
+            ],
+            mode: .searchQuery
+        )
+
+        #expect(ordered == [.window(alpha), .window(beta)])
     }
 
     @Test func reconcileDropsMissingWindowsAndAppendsNewOnes() {


### PR DESCRIPTION
This PR attempts to improve the search experience when switching windows.

- Replaced the DP-based fuzzy scorer with a boundary-aware matcher.
- Changed window ranking to score title and app name separately, prefer title hits, and only use combined app+title matching for multi-term queries.
- Changed app ranking to use the new matcher.
- Added deterministic tie-breaking via normalized labels.
- Aligned blank-query initial selection behavior.
- Added tests for prefix ranking, token-prefix ranking, diacritic-insensitive matching, title-vs-app weighting, and deterministic ordering.
