### PR TITLE
Add app icons to window previews

### DIFF
--- a/window-switcher/Clients/WindowStreamClient.swift
+++ b/window-switcher/Clients/WindowStreamClient.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Sean Zhang on 2025-01-04.
 //
-
+import Observation
 import ScreenCaptureKit
 
 private struct WindowFrameKey: Hashable {
@@ -60,9 +60,11 @@ private extension SCWindow {
 
 // WindowStreams will hold a buffer of WindowStreams
 @MainActor
+@Observable
 class WindowStreamClient {
     private var windowMap: [Window: SCWindow] = [:]
     private var previewCache: [WindowIdentityKey: CGImage] = [:]
+    @ObservationIgnored
     private var initialLoadTask: Task<Void, Never>?
     
     init(_ windows: [Window]) {

--- a/window-switcher/ViewModels/SwitcherViewModel.swift
+++ b/window-switcher/ViewModels/SwitcherViewModel.swift
@@ -57,7 +57,6 @@ extension SwitcherView {
     class ViewModel {
         // State
         var searchItems: [SearchItem] = []
-        var windowPreviewCache: [Window: CGImage] = [:]
         private var applicationSearchTask: Task<Void, Never>?
         private var previewTask: Task<Void, Never>?
         var searchText: String = "" {
@@ -133,7 +132,7 @@ extension SwitcherView {
                 return nil
             }
 
-            return windowPreviewCache[window]
+            return streamClient.cachedWindowPreview(for: window)
         }
 
         private func ensurePreviewLoaded(for item: SearchItem?) {
@@ -142,7 +141,7 @@ extension SwitcherView {
                 return
             }
 
-            guard windowPreviewCache[window] == nil else {
+            guard streamClient.cachedWindowPreview(for: window) == nil else {
                 previewTask = nil
                 return
             }
@@ -153,14 +152,13 @@ extension SwitcherView {
                 }
 
                 do {
-                    let preview = try await self.streamClient.getWindowPreview(
+                    _ = try await self.streamClient.getWindowPreview(
                         for: window,
                         among: self.windowClient.getWindows()
                     )
-                    guard !Task.isCancelled, self.selectedItem == .window(window) else {
+                    guard !Task.isCancelled else {
                         return
                     }
-                    self.windowPreviewCache[window] = preview
                 } catch is CancellationError {
                     return
                 } catch {

--- a/window-switcher/Views/SwitcherView.swift
+++ b/window-switcher/Views/SwitcherView.swift
@@ -56,7 +56,6 @@ struct SwitcherView: View {
             ZStack {
                 WindowImageView(
                     cgImage: viewModel.preview(for: viewModel.selectedItem),
-                    selectedItem: viewModel.selectedItem,
                     appImage: viewModel.selectedItem.map(viewModel.icon(for:))
                 )
             }

--- a/window-switcher/Views/WindowImageView.swift
+++ b/window-switcher/Views/WindowImageView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 
 struct WindowImageView: View {
     let cgImage: CGImage?
-    let selectedItem: SearchItem?
     let appImage: NSImage?
 
     var body: some View {


### PR DESCRIPTION
This PR adds app icons to the window previews (and app previews), and improves the user interface when users switch between selected items.

There was a problem where a gray frame would flash between switching, and this was due to two sources of truth -- one with the selection state, another with the preview state. The fix was to remove the second state, and rely on a function to derive the preview.