### PR TITLE
feat: configurable enter selection keybind

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,9 @@ previous = [
   { key = "k", modifiers = ["control"] },
   { key = "p", modifiers = ["control"] }
 ]
+enter_selection = [
+  { key = "y", modifiers = ["control"] }
+]
 
 [result.window]
 template = "{app_name}: {title}"
@@ -37,11 +40,12 @@ template = "Open {name}"
 | `trigger` | `modifiers` | `array<string>` | `["option"]` | Modifier keys pressed with `trigger.key`. |
 | `navigation` | `next` | `array<table>` | `[{ key = "j", modifiers = ["control"] }, { key = "n", modifiers = ["control"] }]` | One or more shortcuts that move to the next result. |
 | `navigation` | `previous` | `array<table>` | `[{ key = "k", modifiers = ["control"] }, { key = "p", modifiers = ["control"] }]` | One or more shortcuts that move to the previous result. |
+| `navigation` | `enter_selection` | `array<table>` | `[{ key = "y", modifiers = ["control"] }]` | One or more shortcuts that enter the currently selected result. |
 | `result.window` | `template` | `string` | `"{app_name}: {title}"` | Window row template. Use `{property_name}` placeholders. |
 | `result.app` | `template` | `string` | `"Open {name}"` | App row template. Use `{property_name}` placeholders. |
 
 The default navigation bindings add `Control+J` and `Control+N` for next, plus `Control+K` and `Control+P` for previous. Arrow keys still work, and `Tab`
-still advances to the next result.
+still advances to the next result. `Return` still enters the selected result, and `Control+Y` is configured as an additional default binding.
 
 You can bind multiple shortcuts to the same action:
 
@@ -54,6 +58,9 @@ next = [
 previous = [
   { key = "k", modifiers = ["control"] },
   { key = "p", modifiers = ["control"] }
+]
+enter_selection = [
+  { key = "y", modifiers = ["control"] }
 ]
 ```
 

--- a/window-switcher/Config/AppConfig.swift
+++ b/window-switcher/Config/AppConfig.swift
@@ -32,6 +32,7 @@ struct RawShortcutConfig: Decodable {
 struct NavigationConfig: Equatable {
     var next: [TriggerShortcut]
     var previous: [TriggerShortcut]
+    var enterSelection: [TriggerShortcut]
 
     static let `default` = NavigationConfig(
         next: [
@@ -41,6 +42,9 @@ struct NavigationConfig: Equatable {
         previous: [
             TriggerShortcut(key: .k, modifiers: [.control]),
             TriggerShortcut(key: .p, modifiers: [.control])
+        ],
+        enterSelection: [
+            TriggerShortcut(key: .y, modifiers: [.control])
         ]
     )
 }
@@ -48,6 +52,13 @@ struct NavigationConfig: Equatable {
 struct RawNavigationConfig: Decodable {
     var next: RawShortcutListConfig?
     var previous: RawShortcutListConfig?
+    var enterSelection: RawShortcutListConfig?
+
+    enum CodingKeys: String, CodingKey {
+        case next
+        case previous
+        case enterSelection = "enter_selection"
+    }
 }
 
 struct RawShortcutListConfig: Decodable {

--- a/window-switcher/Config/ConfigLoader.swift
+++ b/window-switcher/Config/ConfigLoader.swift
@@ -34,6 +34,9 @@ struct ConfigLoader {
       { key = "k", modifiers = ["control"] },
       { key = "p", modifiers = ["control"] }
     ]
+    enter_selection = [
+      { key = "y", modifiers = ["control"] }
+    ]
 
     [result.window]
     template = "{app_name}: {title}"
@@ -91,6 +94,17 @@ struct ConfigLoader {
                     config.navigation.previous = previous
                 } else {
                     print("warning: invalid navigation.previous config, falling back to default")
+                }
+            }
+
+            if let rawEnterSelection = rawNavigation.enterSelection {
+                if let enterSelection = resolveShortcutList(
+                    rawEnterSelection.shortcuts,
+                    warningLabel: "navigation.enter_selection"
+                ) {
+                    config.navigation.enterSelection = enterSelection
+                } else {
+                    print("warning: invalid navigation.enter_selection config, falling back to default")
                 }
             }
         }

--- a/window-switcher/Views/SwitcherView.swift
+++ b/window-switcher/Views/SwitcherView.swift
@@ -166,10 +166,7 @@ struct SwitcherView: View {
                 closeWindow()
             }
         case .return:
-            if let item = viewModel.selectedItem {
-                viewModel.enterItem(item)
-                closeWindow()
-            }
+            enterSelectedItem()
         case .tab:
             if !key.modifiers.contains(.option) || isQuickSwitch {
                 viewModel.selectNext()
@@ -189,6 +186,11 @@ struct SwitcherView: View {
 
         if matchesAnyShortcut(navigation.next, keyPress: key) {
             viewModel.selectNext()
+            return true
+        }
+
+        if matchesAnyShortcut(navigation.enterSelection, keyPress: key) {
+            enterSelectedItem()
             return true
         }
 
@@ -222,6 +224,15 @@ struct SwitcherView: View {
         default:
             return false
         }
+    }
+
+    private func enterSelectedItem() {
+        guard let item = viewModel.selectedItem else {
+            return
+        }
+
+        viewModel.enterItem(item)
+        closeWindow()
     }
 
     private func installModifierMonitors() {

--- a/window-switcherTests/window_switcherTests.swift
+++ b/window-switcherTests/window_switcherTests.swift
@@ -28,10 +28,15 @@ struct window_switcherTests {
         [navigation.previous]
         key = "p"
         modifiers = ["control"]
+
+        [navigation.enter_selection]
+        key = "y"
+        modifiers = ["control", "shift"]
         """.utf8))
 
         #expect(config.navigation.next == [TriggerShortcut(key: .n, modifiers: [.control, .shift])])
         #expect(config.navigation.previous == [TriggerShortcut(key: .p, modifiers: [.control])])
+        #expect(config.navigation.enterSelection == [TriggerShortcut(key: .y, modifiers: [.control, .shift])])
     }
 
     @Test func configAllowsMultipleNavigationBindingsPerAction() {
@@ -45,6 +50,10 @@ struct window_switcherTests {
           { key = "k", modifiers = ["control"] },
           { key = "p", modifiers = ["control", "shift"] }
         ]
+        enter_selection = [
+          { key = "y", modifiers = ["control"] },
+          { key = "return", modifiers = ["command"] }
+        ]
         """.utf8))
 
         #expect(
@@ -57,6 +66,12 @@ struct window_switcherTests {
             config.navigation.previous == [
                 TriggerShortcut(key: .k, modifiers: [.control]),
                 TriggerShortcut(key: .p, modifiers: [.control, .shift])
+            ]
+        )
+        #expect(
+            config.navigation.enterSelection == [
+                TriggerShortcut(key: .y, modifiers: [.control]),
+                TriggerShortcut(key: .return, modifiers: [.command])
             ]
         )
     }
@@ -74,11 +89,16 @@ struct window_switcherTests {
         [navigation.previous]
         key = "u"
         modifiers = ["control"]
+
+        [navigation.enter_selection]
+        key = "y"
+        modifiers = ["control"]
         """.utf8))
 
         #expect(config.trigger == TriggerShortcut(key: .space, modifiers: [.command]))
         #expect(config.navigation.next == NavigationConfig.default.next)
         #expect(config.navigation.previous == [TriggerShortcut(key: .u, modifiers: [.control])])
+        #expect(config.navigation.enterSelection == [TriggerShortcut(key: .y, modifiers: [.control])])
     }
 
     @Test func configAllowsCustomResultListItemFormatting() {


### PR DESCRIPTION
Make enter selection also remappable -- by default, it is set to `C-y`