### PR TITLE
Fix chrome windows not showing up

### DIFF
--- a/window-switcher.xcodeproj/project.pbxproj
+++ b/window-switcher.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.5.3;
+				MARKETING_VERSION = 0.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher-dev";
 				PRODUCT_NAME = "$(TARGET_NAME)-dev";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -465,7 +465,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 14.6;
-				MARKETING_VERSION = 0.5.3;
+				MARKETING_VERSION = 0.5.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "src.naesna.window-switcher";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/window-switcher/Clients/WindowClient.swift
+++ b/window-switcher/Clients/WindowClient.swift
@@ -1,5 +1,7 @@
 import AppKit
 
+
+
 private func getAttributeValue(
     _ attribute: CFString,
     from element: AXUIElement
@@ -52,22 +54,51 @@ private func isWindowElement(_ element: AXUIElement) -> Bool {
     getRole(element: element) == kAXWindowRole as String
 }
 
+@_silgen_name("_AXUIElementGetWindow")
+private func _AXUIElementGetWindow(_ element: AXUIElement, _ windowID: UnsafeMutablePointer<CGWindowID>) -> AXError
+
 private func makeWindow(
     element: AXUIElement,
     app: NSRunningApplication
 ) -> Window? {
-    guard isWindowElement(element),
-          let title = getWindowName(element: element) else {
+    guard isWindowElement(element) else {
         return nil
     }
 
+    var elementPID: pid_t = 0
+    let resolvedApp: NSRunningApplication
+    if AXUIElementGetPid(element, &elementPID) == .success,
+       let actualApp = NSRunningApplication(processIdentifier: elementPID) {
+        resolvedApp = actualApp
+    } else {
+        resolvedApp = app
+    }
+
+    var title = getWindowName(element: element)
+    if title == nil || title?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+        if WindowClient.isChromePWA(resolvedApp) {
+            var tempID: CGWindowID = 0
+            if _AXUIElementGetWindow(element, &tempID) == .success && tempID != 0 {
+                title = resolvedApp.localizedName ?? "Chrome App"
+            }
+        }
+    }
+
+    guard let windowTitle = title, !windowTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return nil
+    }
+
+    var cgWindowID: CGWindowID = 0
+    let windowID: CGWindowID? = (_AXUIElementGetWindow(element, &cgWindowID) == .success) ? cgWindowID : nil
+
     return Window(
         id: element.hashValue,
-        appName: app.localizedName ?? "Unknown",
-        appPID: app.processIdentifier,
-        name: title,
+        appName: resolvedApp.localizedName ?? "Unknown",
+        appPID: resolvedApp.processIdentifier,
+        name: windowTitle,
         frame: getWindowFrame(element: element),
-        element: element
+        element: element,
+        windowID: windowID
     )
 }
 
@@ -236,6 +267,9 @@ final class WindowClient {
 
             let selfPtr = Unmanaged.passUnretained(self).toOpaque()
             let element = AXUIElementCreateApplication(app.processIdentifier)
+            if Self.isChromeLike(app) {
+                AXUIElementSetAttributeValue(element, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+            }
             let notifications: [CFString] = [
                 kAXTitleChangedNotification as CFString,
                 kAXWindowCreatedNotification as CFString,
@@ -260,7 +294,7 @@ final class WindowClient {
                 }
             }
 
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .commonModes)
+            CFRunLoopAddSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
         }
     }
 
@@ -269,7 +303,7 @@ final class WindowClient {
             return
         }
 
-        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .commonModes)
+        CFRunLoopRemoveSource(CFRunLoopGetMain(), AXObserverGetRunLoopSource(observer), .commonModes)
     }
 
     private func resetObservers() {
@@ -436,8 +470,28 @@ final class WindowClient {
         NSWorkspace.shared.runningApplications.filter { $0.activationPolicy == .regular }
     }
 
+    private static func isChromeLike(_ app: NSRunningApplication) -> Bool {
+        guard let bundleID = app.bundleIdentifier else { return false }
+        let id = bundleID.lowercased()
+        return id.contains("chrome") || id.contains("chromium")
+    }
+
+    private static func isMainChrome(_ app: NSRunningApplication) -> Bool {
+        guard let bundleID = app.bundleIdentifier else { return false }
+        let id = bundleID.lowercased()
+        return id == "com.google.chrome" || id == "org.chromium.chromium"
+    }
+
+    fileprivate static func isChromePWA(_ app: NSRunningApplication) -> Bool {
+        return isChromeLike(app) && !isMainChrome(app)
+    }
+
     private static func getWindows(for app: NSRunningApplication) -> [Window] {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
+
+        if isChromeLike(app) {
+            AXUIElementSetAttributeValue(axApp, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+        }
 
         var result: CFArray?
         guard AXUIElementCopyAttributeValues(axApp, kAXWindowsAttribute as CFString, 0, 100, &result) == .success,
@@ -447,14 +501,22 @@ final class WindowClient {
 
         var windows: [Window] = []
         for axWindow in axWindows {
-            guard let window = makeWindow(element: axWindow, app: app),
-                  !windows.contains(window) else {
+            guard let window = makeWindow(element: axWindow, app: app) else {
+                continue
+            }
+
+            // Ensure the window actually belongs to the app we are querying.
+            // This prevents Chrome PWAs from returning main Chrome windows and vice versa.
+            guard window.appPID == app.processIdentifier else {
+                continue
+            }
+
+            guard !windows.contains(window) else {
                 continue
             }
 
             windows.append(window)
         }
-
         return windows
     }
 

--- a/window-switcher/Clients/WindowClient.swift
+++ b/window-switcher/Clients/WindowClient.swift
@@ -2,137 +2,131 @@ import AppKit
 
 
 
-private func getAttributeValue(
-    _ attribute: CFString,
-    from element: AXUIElement
-) -> CFTypeRef? {
-    var valueRef: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(element, attribute, &valueRef) == .success else {
-        return nil
-    }
-
-    return valueRef
-}
-
-private func getWindowName(element: AXUIElement) -> String? {
-    guard let titleRef = getAttributeValue(kAXTitleAttribute as CFString, from: element),
-          let title = titleRef as? String else {
-        return nil
-    }
-
-    let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmedTitle.isEmpty ? nil : trimmedTitle
-}
-
-private func getWindowAttribute(
-    _ attribute: CFString,
-    from element: AXUIElement
-) -> AXUIElement? {
-    guard let valueRef = getAttributeValue(attribute, from: element) else {
-        return nil
-    }
-
-    // Ensure the CFTypeRef is actually an AXUIElement before bridging.
-    if CFGetTypeID(valueRef) == AXUIElementGetTypeID() {
-        // Safe to force-cast after verifying type ID.
-        return (valueRef as! AXUIElement)
-    } else {
-        return nil
-    }
-}
-
-private func getRole(element: AXUIElement) -> String? {
-    guard let roleRef = getAttributeValue(kAXRoleAttribute as CFString, from: element),
-          let role = roleRef as? String else {
-        return nil
-    }
-
-    return role
-}
-
-private func isWindowElement(_ element: AXUIElement) -> Bool {
-    getRole(element: element) == kAXWindowRole as String
-}
-
 @_silgen_name("_AXUIElementGetWindow")
 private func _AXUIElementGetWindow(_ element: AXUIElement, _ windowID: UnsafeMutablePointer<CGWindowID>) -> AXError
 
-private func makeWindow(
-    element: AXUIElement,
-    app: NSRunningApplication
-) -> Window? {
-    guard isWindowElement(element) else {
-        return nil
-    }
-
-    var elementPID: pid_t = 0
-    let resolvedApp: NSRunningApplication
-    if AXUIElementGetPid(element, &elementPID) == .success,
-       let actualApp = NSRunningApplication(processIdentifier: elementPID) {
-        resolvedApp = actualApp
-    } else {
-        resolvedApp = app
-    }
-
-    var title = getWindowName(element: element)
-    if title == nil || title?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
-        if WindowClient.isChromePWA(resolvedApp) {
-            var tempID: CGWindowID = 0
-            if _AXUIElementGetWindow(element, &tempID) == .success && tempID != 0 {
-                title = resolvedApp.localizedName ?? "Chrome App"
-            }
+private extension AXUIElement {
+    func getAttributeValue(_ attribute: CFString) -> CFTypeRef? {
+        var valueRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(self, attribute, &valueRef) == .success else {
+            return nil
         }
+        return valueRef
     }
 
-    guard let windowTitle = title, !windowTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    func getElementAttribute(_ attribute: CFString) -> AXUIElement? {
+        guard let valueRef = getAttributeValue(attribute) else {
+            return nil
+        }
+        if CFGetTypeID(valueRef) == AXUIElementGetTypeID() {
+            return (valueRef as! AXUIElement)
+        }
         return nil
     }
 
-    var cgWindowID: CGWindowID = 0
-    let windowID: CGWindowID? = (_AXUIElementGetWindow(element, &cgWindowID) == .success) ? cgWindowID : nil
+    var role: String? {
+        getAttributeValue(kAXRoleAttribute as CFString) as? String
+    }
 
-    return Window(
-        id: element.hashValue,
-        appName: resolvedApp.localizedName ?? "Unknown",
-        appPID: resolvedApp.processIdentifier,
-        name: windowTitle,
-        frame: getWindowFrame(element: element),
-        element: element,
-        windowID: windowID
-    )
+    var isWindow: Bool {
+        role == kAXWindowRole as String
+    }
+
+    var windowTitle: String? {
+        guard let title = getAttributeValue(kAXTitleAttribute as CFString) as? String else {
+            return nil
+        }
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    var windowFrame: CGRect? {
+        var positionRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(self, kAXPositionAttribute as CFString, &positionRef) == .success,
+              let positionRef,
+              CFGetTypeID(positionRef) == AXValueGetTypeID() else {
+            return nil
+        }
+        let position = positionRef as! AXValue
+        guard AXValueGetType(position) == .cgPoint else {
+            return nil
+        }
+
+        var sizeRef: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(self, kAXSizeAttribute as CFString, &sizeRef) == .success,
+              let sizeRef,
+              CFGetTypeID(sizeRef) == AXValueGetTypeID() else {
+            return nil
+        }
+        let size = sizeRef as! AXValue
+        guard AXValueGetType(size) == .cgSize else {
+            return nil
+        }
+
+        var origin = CGPoint.zero
+        var dimensions = CGSize.zero
+        guard AXValueGetValue(position, .cgPoint, &origin),
+              AXValueGetValue(size, .cgSize, &dimensions) else {
+            return nil
+        }
+
+        return CGRect(origin: origin, size: dimensions)
+    }
+
+    var windowID: CGWindowID? {
+        var cgWindowID: CGWindowID = 0
+        return (_AXUIElementGetWindow(self, &cgWindowID) == .success) ? cgWindowID : nil
+    }
+
+    var processIdentifier: pid_t? {
+        var pid: pid_t = 0
+        return (AXUIElementGetPid(self, &pid) == .success) ? pid : nil
+    }
 }
 
-private func getWindowFrame(element: AXUIElement) -> CGRect? {
-    var positionRef: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionRef) == .success,
-          let positionRef,
-          CFGetTypeID(positionRef) == AXValueGetTypeID() else {
-        return nil
+extension NSRunningApplication {
+    var requiresAXEnhancedUserInterface: Bool {
+        guard let bundleID = bundleIdentifier else { return false }
+        let id = bundleID.lowercased()
+        return id.contains("chrome") || id.contains("chromium")
     }
-    let position = positionRef as! AXValue
-    guard AXValueGetType(position) == .cgPoint else {
-        return nil
-    }
+}
 
-    var sizeRef: CFTypeRef?
-    guard AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeRef) == .success,
-          let sizeRef,
-          CFGetTypeID(sizeRef) == AXValueGetTypeID() else {
-        return nil
-    }
-    let size = sizeRef as! AXValue
-    guard AXValueGetType(size) == .cgSize else {
-        return nil
-    }
+extension Window {
+    init?(element: AXUIElement, fallbackApp: NSRunningApplication) {
+        guard element.isWindow else {
+            return nil
+        }
 
-    var origin = CGPoint.zero
-    var dimensions = CGSize.zero
-    guard AXValueGetValue(position, .cgPoint, &origin),
-          AXValueGetValue(size, .cgSize, &dimensions) else {
-        return nil
-    }
+        let resolvedApp: NSRunningApplication
+        if let pid = element.processIdentifier,
+           let actualApp = NSRunningApplication(processIdentifier: pid) {
+            resolvedApp = actualApp
+        } else {
+            resolvedApp = fallbackApp
+        }
 
-    return CGRect(origin: origin, size: dimensions)
+        var title = element.windowTitle
+        if title == nil || title?.isEmpty == true {
+            // General Rule: Any real window (having a CGWindowID) that lacks a title
+            // falls back to its application's localized name.
+            if let tempID = element.windowID, tempID != 0 {
+                title = resolvedApp.localizedName ?? "Application Window"
+            }
+        }
+
+        guard let windowTitle = title, !windowTitle.isEmpty else {
+            return nil
+        }
+
+        self.id = element.hashValue
+        self.appName = resolvedApp.localizedName ?? "Unknown"
+        self.appPID = resolvedApp.processIdentifier
+        self.name = windowTitle
+        self.frame = element.windowFrame
+        self.element = element
+        self.windowID = element.windowID
+    }
 }
 
 private func handleObserverEvent(
@@ -267,7 +261,7 @@ final class WindowClient {
 
             let selfPtr = Unmanaged.passUnretained(self).toOpaque()
             let element = AXUIElementCreateApplication(app.processIdentifier)
-            if Self.isChromeLike(app) {
+            if app.requiresAXEnhancedUserInterface {
                 AXUIElementSetAttributeValue(element, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
             }
             let notifications: [CFString] = [
@@ -339,7 +333,7 @@ final class WindowClient {
     }
 
     private func syncWindowIfNeeded(observer: AXObserver, element: AXUIElement) {
-        guard isWindowElement(element),
+        guard element.isWindow,
               let appPID = appPID(for: observer) else {
             return
         }
@@ -373,12 +367,12 @@ final class WindowClient {
     private func moveFocusedWindowToFront(for appPID: Int32) {
         let appElement = AXUIElementCreateApplication(appPID)
 
-        if let focusedWindow = getWindowAttribute(kAXFocusedWindowAttribute as CFString, from: appElement),
+        if let focusedWindow = appElement.getElementAttribute(kAXFocusedWindowAttribute as CFString),
            moveTrackedWindowToFront(element: focusedWindow) {
             return
         }
 
-        if let mainWindow = getWindowAttribute(kAXMainWindowAttribute as CFString, from: appElement) {
+        if let mainWindow = appElement.getElementAttribute(kAXMainWindowAttribute as CFString) {
             _ = moveTrackedWindowToFront(element: mainWindow)
         }
     }
@@ -392,7 +386,7 @@ final class WindowClient {
 
             if let windowIdx = windows.firstIndex(where: { $0.element == element }) {
                 guard let app = NSRunningApplication(processIdentifier: appPID),
-                      let updatedWindow = makeWindow(element: element, app: app) else {
+                      let updatedWindow = Window(element: element, fallbackApp: app) else {
                     windows.remove(at: windowIdx)
                     reconcileRecentWindowKeys()
                     return
@@ -406,7 +400,7 @@ final class WindowClient {
 
         case kAXWindowMovedNotification, kAXWindowResizedNotification:
             if let windowIdx = windows.firstIndex(where: { $0.element == element }) {
-                windows[windowIdx].frame = getWindowFrame(element: element)
+                windows[windowIdx].frame = element.windowFrame
                 reconcileRecentWindowKeys()
             } else {
                 syncWindowIfNeeded(observer: observer, element: element)
@@ -470,26 +464,10 @@ final class WindowClient {
         NSWorkspace.shared.runningApplications.filter { $0.activationPolicy == .regular }
     }
 
-    private static func isChromeLike(_ app: NSRunningApplication) -> Bool {
-        guard let bundleID = app.bundleIdentifier else { return false }
-        let id = bundleID.lowercased()
-        return id.contains("chrome") || id.contains("chromium")
-    }
-
-    private static func isMainChrome(_ app: NSRunningApplication) -> Bool {
-        guard let bundleID = app.bundleIdentifier else { return false }
-        let id = bundleID.lowercased()
-        return id == "com.google.chrome" || id == "org.chromium.chromium"
-    }
-
-    fileprivate static func isChromePWA(_ app: NSRunningApplication) -> Bool {
-        return isChromeLike(app) && !isMainChrome(app)
-    }
-
     private static func getWindows(for app: NSRunningApplication) -> [Window] {
         let axApp = AXUIElementCreateApplication(app.processIdentifier)
 
-        if isChromeLike(app) {
+        if app.requiresAXEnhancedUserInterface {
             AXUIElementSetAttributeValue(axApp, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
         }
 
@@ -501,7 +479,7 @@ final class WindowClient {
 
         var windows: [Window] = []
         for axWindow in axWindows {
-            guard let window = makeWindow(element: axWindow, app: app) else {
+            guard let window = Window(element: axWindow, fallbackApp: app) else {
                 continue
             }
 

--- a/window-switcher/Clients/WindowStreamClient.swift
+++ b/window-switcher/Clients/WindowStreamClient.swift
@@ -149,34 +149,59 @@ class WindowStreamClient {
             onScreenWindowsOnly: true
         )
         
-        var windowsByIdentity: [WindowIdentityKey: [Window]] = [:]
-        var windowsByTitle: [WindowTitleKey: [Window]] = [:]
+        var scWindowsById: [CGWindowID: SCWindow] = [:]
+        for scWindow in content.windows {
+            scWindowsById[scWindow.windowID] = scWindow
+        }
+
+        var windowMap: [Window: SCWindow] = [:]
+        var unmatchedWindows: [Window] = []
+
+        // 1. First pass: Match precisely by CGWindowID
         for window in windows {
-            windowsByTitle[window.previewTitleKey, default: []].append(window)
-            if let key = window.previewIdentityKey {
-                windowsByIdentity[key, default: []].append(window)
+            if let windowID = window.windowID, let scWindow = scWindowsById[windowID] {
+                windowMap[window] = scWindow
+            } else {
+                unmatchedWindows.append(window)
             }
         }
 
-        var matchedWindows: Set<Window> = []
-        var windowMap: [Window: SCWindow] = [:]
-        for scWindow in content.windows {
-            if let key = scWindow.previewIdentityKey,
-               let window = Self.popFirst(for: key, from: &windowsByIdentity, excluding: matchedWindows) {
-                matchedWindows.insert(window)
-                windowMap[window] = scWindow
-                continue
+        // 2. Second pass: Fall back to heuristics for any unmatched windows
+        if !unmatchedWindows.isEmpty {
+            var windowsByIdentity: [WindowIdentityKey: [Window]] = [:]
+            var windowsByTitle: [WindowTitleKey: [Window]] = [:]
+            for window in unmatchedWindows {
+                windowsByTitle[window.previewTitleKey, default: []].append(window)
+                if let key = window.previewIdentityKey {
+                    windowsByIdentity[key, default: []].append(window)
+                }
             }
 
-            if let title = scWindow.previewTitleKey,
-               let window = Self.uniqueCandidate(for: title, from: windowsByTitle, excluding: matchedWindows) {
-                matchedWindows.insert(window)
-                windowMap[window] = scWindow
+            var matchedWindows: Set<Window> = []
+            for scWindow in content.windows {
+                // Skip if this scWindow is already matched to a window in the first pass
+                if windowMap.values.contains(where: { $0.windowID == scWindow.windowID }) {
+                    continue
+                }
+
+                if let key = scWindow.previewIdentityKey,
+                   let window = Self.popFirst(for: key, from: &windowsByIdentity, excluding: matchedWindows) {
+                    matchedWindows.insert(window)
+                    windowMap[window] = scWindow
+                    continue
+                }
+
+                if let title = scWindow.previewTitleKey,
+                   let window = Self.uniqueCandidate(for: title, from: windowsByTitle, excluding: matchedWindows) {
+                    matchedWindows.insert(window)
+                    windowMap[window] = scWindow
+                }
             }
         }
         
         return windowMap
     }
+
 
     private static func popFirst<Key: Hashable>(for key: Key, from matches: inout [Key: [Window]], excluding matchedWindows: Set<Window>) -> Window? {
         guard var windows = matches[key] else {

--- a/window-switcher/Models/Windows.swift
+++ b/window-switcher/Models/Windows.swift
@@ -7,6 +7,7 @@ struct Window: Hashable {
     var name: String
     var frame: CGRect?
     var element: AXUIElement
+    var windowID: CGWindowID? = nil
 
     var fullyQualifiedName: String {
         "\(appName): \(name)"


### PR DESCRIPTION
* Toggled the "AXEnhancedUserInterface" attribute on Chrome UI elements to force exposure of Chrome browser window hierarchies.
* Replaced title and coordinate heuristics with `CGWindowID` for matching via the system's `_AXUIElementGetWindow` API.
* Resolved true window owner PIDs using AXUIElementGetPid to prevent main Chrome windows from being misattributed to PWA shims (like Gmail) during tab switches.
* Bound all accessibility event observers to CFRunLoopGetMain() instead of thread-local run loops, restoring real-time window creation and title update notifications.

Fixes #57
