### PR TITLE
Keep windows of hidden applications in switcher list

### DIFF
--- a/window-switcher/Clients/WindowClient.swift
+++ b/window-switcher/Clients/WindowClient.swift
@@ -433,11 +433,7 @@ final class WindowClient {
             moveFocusedWindowToFront(for: appPID)
 
         case kAXApplicationHiddenNotification:
-            guard let appPID = appPID(for: observer) else {
-                return
-            }
-
-            removeWindows(for: appPID)
+            break
 
         case kAXApplicationShownNotification:
             guard let appPID = appPID(for: observer) else {


### PR DESCRIPTION
This PR stops windows from being removed on events that hide the app.

Fixes #56 